### PR TITLE
Commands should support additional parameters like -Pre

### DIFF
--- a/nuget-button.js
+++ b/nuget-button.js
@@ -38,7 +38,13 @@
             var textNode = document.createTextNode(textContent);
             node.appendChild(textNode);
         },
-
+        appendOtherCharacters = function(element, array) {
+            for(var index = 2; index < array.length; index++)
+            {
+                var str = ' ' + array[index];
+                text(element, str);
+            }
+        },
         createElement = function (name) {
             return document.createElement(name);
         },
@@ -98,6 +104,7 @@
                     text(anchor, packageName);
                     command.appendChild(anchor);
                 }
+                appendOtherCharacters(command, str)
                 commandPrompt.appendChild(command);
                 pre.parentNode.replaceChild(commandWrapper, pre);
             }

--- a/nuget-button.js
+++ b/nuget-button.js
@@ -72,7 +72,7 @@
             for (var i = 0; i < totalButtons; ++i) {
                 var pre = buttons[i],
                     str = pre.innerHTML.split(' ');
-                if (str.length !== 2 || str[0] !== installPackageText) {
+                if (str[0] !== installPackageText) {
                     continue;
                 }
 


### PR DESCRIPTION
I wanted to use this widget on a page where I included both stable and pre-release packages and, well, it didn't work as I expected.

So I dropped that constraint and I'm a happy coder again. And added in a function to render any additional parameters.
